### PR TITLE
Fix header in bachelor

### DIFF
--- a/nuaathesis.dtx
+++ b/nuaathesis.dtx
@@ -202,7 +202,7 @@
 %    \end{macrocode}
 % 其他地方用到的常量：
 %    \begin{macrocode}
-\newcommand\nuaa@label@reportpaper{报告纸}
+\newcommand\nuaa@label@reportpaper{毕业设计（论文）报告纸}
 \newcommand\nuaa@label@tableofcontents{目\quad 录}
 \newcommand\nuaa@label@listoffigurestables{图表清单}
 \newcommand\nuaa@label@figurename{图}
@@ -562,7 +562,7 @@
         \put(7.3,1.5){\includegraphics[width=6cm]{\nuaa@universityLogo}}
       \end{picture}
     }
-    \fancyhead[R]{\songti\zihao{4}\nuaa@worktypecn \nuaa@label@reportpaper\hspace{1\ccwd}}
+    \fancyhead[R]{\songti\zihao{4}\nuaa@label@reportpaper\hspace{1\ccwd}}
   \else
     \fancyhead[C]{
       \songti\zihao{5}


### PR DESCRIPTION
fix #13 
本科页眉永远显示 `毕业设计（论文）报告纸`，而非根据当前文章内容，显示其中一个。