### PR TITLE
keep font when use \url

### DIFF
--- a/nuaathesis.dtx
+++ b/nuaathesis.dtx
@@ -1129,6 +1129,7 @@ and the derived files           nuaathesis.ins,
 \RequirePackage{multicol}
 \RequirePackage{caption}   % DeclareCaptionFont
 \RequirePackage{hyperref}
+\urlstyle{same} % 在使用\url时保持相同字体
 \RequirePackage{ifxetex}
 \RequirePackage{siunitx}
 \RequirePackage{amsmath}


### PR DESCRIPTION
\url会默认使用mono字体，解决方案参考了[这里](https://tex.stackexchange.com/questions/261434/changing-url-font)