### PR TITLE
fix(nuaabib): lang has nothing to do with masters/phd thesis ref format

### DIFF
--- a/demo_chs/bib/sample.bib
+++ b/demo_chs/bib/sample.bib
@@ -420,6 +420,7 @@
   volume       = {57},
   number       = {34},
   pages        = {3219},
+  lang         = {zh},
 }
 
 @article{n12,
@@ -440,6 +441,7 @@
   publisher    = {中国人民大学出版社},
   year         = {2012},
   pages        = {235--236},
+  lang         = {zh},
 }
 
 @book{n22,
@@ -449,6 +451,7 @@
   publisher    = {中国人民大学出版社},
   year         = {2012},
   pages        = {235--236},
+  lang         = {zh},
 }
 
 @incollection{n31,
@@ -460,6 +463,7 @@
   publisher    = {科学出版社},
   year         = {1999},
   pages        = {32--36},
+  lang         = {zh},
 }
 
 @incollection{n32,
@@ -471,6 +475,7 @@
   publisher    = {科学出版社},
   year         = {1999},
   pages        = {32--36},
+  lang         = {zh},
 }
 
 @phdthesis{n41,
@@ -481,6 +486,7 @@
   year         = {2011},
   pages        = {27},
   urldate      = {2013-10-14},
+  lang         = {zh},
 }
 
 @phdthesis{n42,
@@ -490,6 +496,7 @@
   school       = {北京大学},
   year         = {2003},
   urldate      = {2013-10-14},
+  lang         = {zh},
 }
 
 @phdthesis{n43,

--- a/nuaabib.bst
+++ b/nuaabib.bst
@@ -1000,7 +1000,7 @@ FUNCTION {manual}
   fin.entry
 }
 
-FUNCTION {masterthesis.type}
+FUNCTION {mastersthesis.type}
 { lang empty$
     { "[D]" }
     { "\thumasterbib" }
@@ -1011,8 +1011,9 @@ FUNCTION {mastersthesis}
 { output.bibitem
   format.authors "author" add.period$ output.check
   new.block
-  % format.title remove.dots ": " * masterthesis.type * output
-  format.title remove.dots masterthesis.type * output
+  % format.title remove.dots ": " * mastersthesis.type * output
+  % format.title remove.dots mastersthesis.type * output
+  format.title remove.dots "[D]" * output
   new.block
   format.address.school output
   %format.madd "address" output.check
@@ -1050,7 +1051,8 @@ FUNCTION {phdthesis}
   format.authors "author" add.period$ output.check
   new.block
   % format.title remove.dots ": " * phdthesis.type * output
-  format.title remove.dots phdthesis.type * output
+  % format.title remove.dots phdthesis.type * output
+  format.title remove.dots "[D]" * output
   new.block
   format.address.school output
   %address output


### PR DESCRIPTION
* `lang` 与硕士/博士论文引用的类型 `[D]` 无关，且项目中并无 `\thumasterbib` 以及 `\thuphdbib` ，故将其直接输出为 `[D]` ；
* [中文引用论文中有多个作者](https://github.com/nuaatug/nuaathesis/issues/1#issuecomment-494332979)时，需要在 `*.bib` 文件项目中加入 `lang` 的标签，故补充了 `sample.bib` 。